### PR TITLE
Test actions/setup-node

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 16.15.1
       - run: gh api -X GET /rate_limit -q .resources.core.remaining | tee -a $GITHUB_STEP_SUMMARY
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,10 +20,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        index: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']
+        index: ['1', '2', '3', '4', '5']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - run: gh api -X GET /rate_limit -q .resources.core.remaining | tee -a $GITHUB_STEP_SUMMARY
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,13 @@ jobs:
         index: ['1', '2', '3', '4', '5']
     runs-on: ubuntu-latest
     steps:
+      - run: gh api -X GET /rate_limit -q .resources.core.remaining | tee -a $GITHUB_STEP_SUMMARY
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3
+      - run: gh api -X GET /rate_limit -q .resources.core.remaining | tee -a $GITHUB_STEP_SUMMARY
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v3
         with:
           node-version: 16.15.1


### PR DESCRIPTION
## Node 16
https://github.com/int128/test-github-token-rate-limit/actions/runs/2898048405

<img width="960" alt="image" src="https://user-images.githubusercontent.com/321266/185785877-c79b8973-1a46-4f18-bbbd-5c10c4467538.png">
<img width="960" alt="image" src="https://user-images.githubusercontent.com/321266/185785882-cc5a9910-9a10-4511-9aa6-7f1a476cee16.png">

## Node 16.15.1
setup-node consumes 2 of rate limit.

https://github.com/int128/test-github-token-rate-limit/actions/runs/2898383778

<img width="960" alt="image" src="https://user-images.githubusercontent.com/321266/185790312-acc06f6f-ddcd-40f8-915f-136ed91caef7.png">
<img width="960" alt="image" src="https://user-images.githubusercontent.com/321266/185790319-e9c5efbe-cd0c-429e-829b-7bd57b2ece7d.png">

